### PR TITLE
Update providers.json

### DIFF
--- a/burst/providers/providers.json
+++ b/burst/providers/providers.json
@@ -756,7 +756,7 @@
             "row": "find_once('table', ('id', 'torrenttable')).find_all('tr')",
             "seeds": "item(tag='td', order=7)",
             "size": "item(tag='td', order=5)",
-            "torrent": "item(tag='a', attribute='href', order=5)"
+            "torrent": "item(tag='a', attribute='href', order=5).replace('/download', 'https://www.torrentleech.org/download')"
         },
         "private": true,
         "season_extra": "",


### PR DESCRIPTION
Torrent download link on TL site is like this:
`<a href="/download/1058223/blahblah.torrent">`
so it fails to bring back the results for TL. The full domain name must be added.